### PR TITLE
update zmq-service-suite-message and uuid to 0.0.3 and 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "dependencies": {
     "lodash": "^3.10.1",
-    "uuid": "~1.4.1",
+    "uuid": "^2.0.1",
     "zmq": "^2.7.0",
-    "zmq-service-suite-message": "0.0.2"
+    "zmq-service-suite-message": "0.0.3"
   },
   "engines": {
     "node": ">=0.10.28"


### PR DESCRIPTION
when upgraded separatly was causing some issues on some tests since
spyOn wasnt working properly.